### PR TITLE
add a go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,26 @@
+module github.com/raboof/beats-output-http
+
+go 1.14
+
+require (
+	github.com/elastic/beats/v7 v7.10.1
+)
+
+// needed because elastic wants these replacements, and https://github.com/golang/go/issues/30354#issuecomment-466479708
+replace (
+	github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.2.0+incompatible
+	github.com/Microsoft/go-winio => github.com/bi-zone/go-winio v0.4.15
+	github.com/Shopify/sarama => github.com/elastic/sarama v1.19.1-0.20200629123429-0e7b69039eec
+	github.com/cucumber/godog => github.com/cucumber/godog v0.8.1
+	github.com/docker/docker => github.com/docker/engine v0.0.0-20191113042239-ea84732a7725
+	github.com/docker/go-plugins-helpers => github.com/elastic/go-plugins-helpers v0.0.0-20200207104224-bdf17607b79f
+	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
+	github.com/dop251/goja_nodejs => github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
+	github.com/fsnotify/fsevents => github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270
+	github.com/fsnotify/fsnotify => github.com/adriansr/fsnotify v0.0.0-20180417234312-c9bbe1f46f1d
+	github.com/google/gopacket => github.com/adriansr/gopacket v1.1.18-0.20200327165309-dd62abfa8a41
+	github.com/insomniacslk/dhcp => github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3 // indirect
+	github.com/kardianos/service => github.com/blakerouse/service v1.1.1-0.20200924160513-057808572ffa
+	github.com/tonistiigi/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
+	golang.org/x/tools => golang.org/x/tools v0.0.0-20200602230032-c00d67ef29d0 // release 1.14
+)


### PR DESCRIPTION
To make it possible to fetch the beats dependency, as that's
only published as a module now.

Eventually we'd want to migrate all dependency information from
glide.lock to go.mod

Unfortunately 'go get' doesn't take into account transitive
replacements, so we need to include the replacements required
by beats to make the build succeed on Travis.